### PR TITLE
Only add `--no-run-if-empty` if GNU xargs is detected.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,12 @@ Install ``nose``, then run the tests via::
 History
 -------
 
+Version 0.9.3
+^^^^^^^^^^^^^
+
+- Only use ``--no-run-if-empty`` if we have GNU xargs.  BSD xargs does not
+  support the option, but implements the behavior by default.
+
 Version 0.9.2
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
This means that findx now works with the native BSD xargs, which
implements the `--no-run-if-empty` behavior by default--despite POSIX
saying the tool should be run at least once.

I went the detection route because it is possible that GNU grep is
present, if someone installed grep with Homebrew using the
`--default-names` option.
